### PR TITLE
Remove extra trailing newline

### DIFF
--- a/lib/rules/no-global.js
+++ b/lib/rules/no-global.js
@@ -49,7 +49,7 @@ module.exports = {
             )
             .map(
               (specifier) =>
-                `import ${specifier.imported.name} from 'lodash/${specifier.imported.name}';\n`
+                `import ${specifier.imported.name} from 'lodash/${specifier.imported.name}';`
             );
 
           if (imports.length > 0) {
@@ -57,7 +57,7 @@ module.exports = {
               node,
               messageId: "invalidImport",
               fix(fixer) {
-                return fixer.replaceText(node, imports.join(""));
+                return fixer.replaceText(node, imports.join("\n"));
               },
             });
           }

--- a/tests/lib/rules/index.js
+++ b/tests/lib/rules/index.js
@@ -17,13 +17,13 @@ ruleTester.run("lodash-specific-import/no-global", rule, {
     {
       code: "import { map } from 'lodash';",
       errors: [{ messageId: "invalidImport" }],
-      output: "import map from 'lodash/map';\n",
+      output: "import map from 'lodash/map';",
     },
     {
       code: "import {isEmpty, map} from 'lodash';",
       errors: [{ messageId: "invalidImport" }],
       output:
-        "import isEmpty from 'lodash/isEmpty';\nimport map from 'lodash/map';\n",
+        "import isEmpty from 'lodash/isEmpty';\nimport map from 'lodash/map';",
     },
     {
       code: "import _ from 'lodash';",


### PR DESCRIPTION
## Summary

This PR fixes an issue in the ESLint rule `no-global` where newline characters (`\n`) were incorrectly added within individual import strings rather than during the final join operation. It also updates the corresponding tests to align with the new rule behavior.

## Changes

- Updated `no-global.js` to move newline characters into the `join` operation when replacing text.
- Ensured cleaner and more predictable formatting for auto-fixes.
- Updated test expectations in `tests/lib/rules/index.js` to reflect the updated fix output.

## Testing instructions

1. Run `npm test` or your test command to verify all ESLint rule tests pass.
2. Confirm that multiple named imports from `lodash` are now replaced with individual import lines, joined by `\n`, without additional trailing newlines.
3. Confirm that auto-fixes no longer include newline characters at the end of each import string.

## Links

- Fixes #1
