### PR TITLE
feat(lodash-es): add `lodash-es` support to no-global rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A lightweight ESLint plugin to enforce specific lodash imports.
 
 ## ✨ Features
 
-* Prevents full lodash imports (`import _ from 'lodash'`)
-* Enforces specific function imports (`import debounce from 'lodash/debounce'`)
+* Prevents full lodash imports (`import _ from 'lodash'` or `import _ from 'lodash-es'`)
+* Enforces specific function imports (`import debounce from 'lodash/debounce'` or `import debounce from 'lodash-es/debounce'`)
 * Simple drop-in ESLint rule
 * **Auto-generated documentation** using [eslint-doc-generator](https://github.com/eslint/eslint-doc-generator)
 
@@ -53,13 +53,17 @@ Add to your ESLint config (e.g., `.eslintrc.json`):
 ```js
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
+import debounce from 'lodash-es/debounce';
+import isEmpty from 'lodash-es/isEmpty';
 ```
 
 **❌ Bad:**
 
 ```js
 import _ from 'lodash';
+import _ from 'lodash-es';
 const lodash = require('lodash');
+const lodashEs = require('lodash-es');
 ```
 
 ---

--- a/docs/rules/no-global.md
+++ b/docs/rules/no-global.md
@@ -3,3 +3,5 @@
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->
+
+This rule also applies to `lodash-es` imports (for example, `import { map } from 'lodash-es'`).

--- a/lib/rules/no-global.js
+++ b/lib/rules/no-global.js
@@ -19,7 +19,7 @@ module.exports = {
   create(context) {
     return {
       ImportDeclaration(node) {
-        if (node.source.value !== "lodash") {
+        if (node.source.value !== "lodash" && node.source.value !== "lodash-es") {
           return;
         }
         const hasDefaultImport = node.specifiers.some(
@@ -49,7 +49,7 @@ module.exports = {
             )
             .map(
               (specifier) =>
-                `import ${specifier.imported.name} from 'lodash/${specifier.imported.name}';`
+                `import ${specifier.imported.name} from '${node.source.value}/${specifier.imported.name}';`
             );
 
           if (imports.length > 0) {
@@ -70,7 +70,7 @@ module.exports = {
           node.init.callee.name === "require" &&
           node.init.arguments.length === 1 &&
           node.init.arguments[0].type === "Literal" &&
-          node.init.arguments[0].value === "lodash"
+          (node.init.arguments[0].value === "lodash" || node.init.arguments[0].value === "lodash-es")
         ) {
           if (node.id.type === "ObjectPattern") {
             context.report({

--- a/tests/lib/rules/index.js
+++ b/tests/lib/rules/index.js
@@ -11,6 +11,8 @@ ruleTester.run("lodash-specific-import/no-global", rule, {
   valid: [
     "import map from 'lodash/map';",
     "import type { Map } from 'lodash';",
+    "import map from 'lodash-es/map';",
+    "import type { Map } from 'lodash-es';",
   ],
 
   invalid: [
@@ -38,7 +40,33 @@ ruleTester.run("lodash-specific-import/no-global", rule, {
     {
       code: "const { map } = require('lodash');",
       errors: [{ messageId: "invalidImport" }],
-      output: null, // Output is null because automatic fixing is not supported for this case
+      output: null,
+    },
+    {
+      code: "import { map } from 'lodash-es';",
+      errors: [{ messageId: "invalidImport" }],
+      output: "import map from 'lodash-es/map';",
+    },
+    {
+      code: "import {isEmpty, map} from 'lodash-es';",
+      errors: [{ messageId: "invalidImport" }],
+      output:
+        "import isEmpty from 'lodash-es/isEmpty';\nimport map from 'lodash-es/map';",
+    },
+    {
+      code: "import _ from 'lodash-es';",
+      errors: [{ messageId: "invalidDefaultImport" }],
+      output: null,
+    },
+    {
+      code: "const _ = require('lodash-es');",
+      errors: [{ messageId: "invalidDefaultImport" }],
+      output: null,
+    },
+    {
+      code: "const { map } = require('lodash-es');",
+      errors: [{ messageId: "invalidImport" }],
+      output: null,
     },
   ],
 });


### PR DESCRIPTION
Hey, thanks for this amazing eslint rule, saved me a bunch of time.

But I noticed it's missing support for lodash-es, so this PR covers it.

---

## Summary

This PR extends the `no-global` rule to support `lodash-es`, enforcing the same specific-import behavior as `lodash` and preventing global or default imports.

## Changes

* Updated the `no-global` rule to treat `lodash-es` the same as `lodash` for import validation.
  * Extended auto-fix logic to generate scoped imports from `lodash-es/<method>`.
* Added test coverage for `lodash-es` import and require cases.
* Updated README examples to document `lodash-es` support.
* Clarified rule documentation to explicitly mention `lodash-es`.

## Testing instructions

1. Run the test suite for the ESLint plugin.
2. Verify that `import { map } from 'lodash-es'` is reported and auto-fixed to `import map from 'lodash-es/map'`.
3. Confirm that default imports from `lodash-es` are reported as invalid.
4. Ensure existing `lodash` behavior remains unchanged.
