### PR TITLE
Add dual module exports and package compatibility checks

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -1,0 +1,3 @@
+import plugin from "./index.js";
+
+export default plugin;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,13 @@
   ],
   "author": "Darshan Jain <djainj86@gmail.com>",
   "main": "./lib/index.js",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs",
+      "default": "./lib/index.js"
+    }
+  },
   "scripts": {
     "lint": "npm-run-all \"lint:*\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs --check \"",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+    "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=7"
+    "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "license": "MIT",
   "repository": {

--- a/tests/lib/module-exports.js
+++ b/tests/lib/module-exports.js
@@ -1,0 +1,27 @@
+const assert = require("assert");
+
+const cjsPlugin = require("../../lib/index.js");
+const importEsm = new Function("path", "return import(path);");
+
+describe("module export parity", () => {
+  it("loads plugin via cjs require", () => {
+    assert(cjsPlugin);
+    assert(cjsPlugin.rules);
+    assert.strictEqual(typeof cjsPlugin.rules["no-global"], "object");
+  });
+
+  it("loads plugin via esm import", async () => {
+    const esmModule = await importEsm("../../lib/index.mjs");
+    assert(esmModule.default);
+    assert(esmModule.default.rules);
+    assert.strictEqual(typeof esmModule.default.rules["no-global"], "object");
+  });
+
+  it("exposes equivalent top-level keys in cjs and esm", async () => {
+    const esmModule = await importEsm("../../lib/index.mjs");
+    const cjsKeys = Object.keys(cjsPlugin).sort();
+    const esmKeys = Object.keys(esmModule.default).sort();
+
+    assert.deepStrictEqual(esmKeys, cjsKeys);
+  });
+});


### PR DESCRIPTION


## Summary

This PR updates the package to support both CommonJS and ESM consumers, aligns the package metadata with the intended runtime and peer support, and adds smoke tests to confirm both entrypoints expose the same plugin shape.

## Changes

- Added `lib/index.mjs` as an ESM entrypoint that re-exports the plugin default export from `lib/index.js`.
- Updated `package.json` `exports` to use conditional exports for `require` and `import`.
- Kept `./lib/index.js` as the default/CommonJS entrypoint.
- Updated the Node engine requirement from `^14.17.0 || ^16.0.0 || >= 18.0.0` to `>=20.0.0`.
- Updated the ESLint peer dependency range from `>=7` to `^8.0.0 || ^9.0.0 || ^10.0.0`.
- Added `tests/lib/module-exports.js` to verify the plugin loads correctly through both `require` and dynamic `import`.
- Added a parity test to confirm the CommonJS and ESM entrypoints expose the same top-level keys.
- Added smoke coverage to confirm the `no-global` rule is available from both module formats.
