### PR TITLE
Add CI compatibility matrix and alpha release readiness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+      - "feat/**"
+      - "chore/**"
+      - "fix/**"
+      - "tests/**"
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20"]
+        eslint-version: ["8", "9", "10"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pin ESLint major under test
+        run: npm install --no-save eslint@${{ matrix.eslint-version }}
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,52 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
+          cache: yarn
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Pin ESLint major under test
-        run: npm install --no-save eslint@${{ matrix.eslint-version }}
+        run: yarn add --dev eslint@${{ matrix.eslint-version }}
 
       - name: Lint
-        run: npm run lint
+        run: yarn lint
 
       - name: Test
-        run: npm test
+        run: yarn test
+
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Validate generated docs
+        run: yarn check:docs
+
+  package-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Smoke check package tarball
+        run: yarn check:pack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
   pull_request:
+    types:
+      - opened
 
 jobs:
   lint-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-      - "release/**"
-      - "feat/**"
-      - "chore/**"
-      - "fix/**"
-      - "tests/**"
   pull_request:
 
 jobs:
@@ -32,8 +25,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Pin ESLint major under test
-        run: yarn add --dev eslint@${{ matrix.eslint-version }}
+      - name: Pin ESLint and @eslint/js majors under test
+        run: yarn add --dev eslint@${{ matrix.eslint-version }} @eslint/js@${{ matrix.eslint-version }}
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20"]
+        node-version: ["24"]
         eslint-version: ["8", "9", "10"]
     steps:
       - name: Checkout
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
           cache: yarn
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
           cache: yarn
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         eslint-version: ["8", "9", "10"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: yarn
@@ -56,10 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: yarn

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+.npm-cache

--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ module.exports = [
 
 * Node.js: `>=20`
 * ESLint: `^8 || ^9 || ^10`
-* Config styles: legacy `.eslintrc*` and flat `eslint.config.*`
+* Config styles:
+  * ESLint 8/9: legacy `.eslintrc*` and flat `eslint.config.*`
+  * ESLint 10: flat `eslint.config.*` only
 * Module support: CommonJS + ESM entrypoints
 
 ### Migration Notes (alpha)
 
 * Prefer the flat config format for new projects.
-* Legacy `.eslintrc*` remains supported during this alpha track.
+* Legacy `.eslintrc*` remains supported for ESLint 8/9 (ESLint 10 is flat-config-only).
 * Rule fixer hardening for alias/mixed-import edge cases is deferred to a follow-up PR.
 
 ---

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ module.exports = [
 
 ### Compatibility (v2.0.0-alpha track)
 
-* Node.js: `>=20`
+* Node.js: `>=22`
 * ESLint: `^8 || ^9 || ^10`
 * Config styles:
   * ESLint 8/9: legacy `.eslintrc*` and flat `eslint.config.*`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,36 @@ module.exports = [
 }
 ```
 
+### Flat Config (`eslint.config.cjs` / `eslint.config.js`)
+
+```js
+const lodashSpecificImportPlugin = require("eslint-plugin-lodash-specific-import");
+
+module.exports = [
+  {
+    plugins: {
+      "lodash-specific-import": lodashSpecificImportPlugin,
+    },
+    rules: {
+      "lodash-specific-import/no-global": "error",
+    },
+  },
+];
+```
+
+### Compatibility (v2.0.0-alpha track)
+
+* Node.js: `>=20`
+* ESLint: `^8 || ^9 || ^10`
+* Config styles: legacy `.eslintrc*` and flat `eslint.config.*`
+* Module support: CommonJS + ESM entrypoints
+
+### Migration Notes (alpha)
+
+* Prefer the flat config format for new projects.
+* Legacy `.eslintrc*` remains supported during this alpha track.
+* Rule fixer hardening for alias/mixed-import edge cases is deferred to a follow-up PR.
+
 ---
 
 ## 🔍 Rule Example

--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "eslint-plugin"
   ],
   "author": "Darshan Jain <djainj86@gmail.com>",
+  "files": [
+    "lib",
+    "docs",
+    "README.md",
+    "LICENSE"
+  ],
   "main": "./lib/index.js",
   "exports": {
     ".": {
@@ -17,6 +23,8 @@
     }
   },
   "scripts": {
+    "check:docs": "npm run lint:eslint-docs",
+    "check:pack": "npm pack --dry-run --cache /tmp/eslint-plugin-lodash-specific-import-npm-cache > /dev/null",
     "lint": "npm-run-all \"lint:*\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs --check \"",
     "lint:js": "eslint . --ignore-pattern \"tests/fixtures/**\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-lodash-specific-import",
-  "version": "1.0.3",
+  "version": "2.0.0-alpha.0",
   "description": "An ESLint plugin to enforce specific lodash imports, preventing global or named imports from 'lodash'.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "peerDependencies": {
     "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     }
   },
   "scripts": {
-    "check:docs": "npm run lint:eslint-docs",
-    "check:pack": "npm pack --dry-run --cache /tmp/eslint-plugin-lodash-specific-import-npm-cache > /dev/null",
+    "check:docs": "yarn lint:eslint-docs",
+    "check:pack": "npm pack --dry-run --cache .npm-cache",
     "lint": "npm-run-all \"lint:*\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs --check \"",
     "lint:js": "eslint . --ignore-pattern \"tests/fixtures/**\"",

--- a/tests/lib/config-parity.js
+++ b/tests/lib/config-parity.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 const fs = require("fs");
 const path = require("path");
 const eslintMajor = Number(require("eslint/package.json").version.split(".")[0]);
-const disableLookupFlag = eslintMajor >= 9 ? "--no-config-lookup" : "--no-eslintrc";
+const disableLookupFlag = "--no-eslintrc";
 const supportsLegacyEslintrc = eslintMajor < 10;
 const { repoRoot, runEslintJson } = require("./helpers/eslint-runner");
 
@@ -38,7 +38,7 @@ describe("legacy and flat config parity", () => {
       legacyTarget,
       "--format",
       "json",
-    ], { stdin: source });
+    ], { stdin: source, env: { ESLINT_USE_FLAT_CONFIG: "false" } });
 
     const flatResult = runEslintJson([
       "--config",

--- a/tests/lib/legacy-config.js
+++ b/tests/lib/legacy-config.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 const fs = require("fs");
 const path = require("path");
 const eslintMajor = Number(require("eslint/package.json").version.split(".")[0]);
-const disableLookupFlag = eslintMajor >= 9 ? "--no-config-lookup" : "--no-eslintrc";
+const disableLookupFlag = "--no-eslintrc";
 const supportsLegacyEslintrc = eslintMajor < 10;
 const { repoRoot, runEslintJson, toRepoPath } = require("./helpers/eslint-runner");
 
@@ -23,7 +23,7 @@ describe("legacy eslintrc integration", () => {
       target,
       "--format",
       "json",
-    ], { stdin: source });
+    ], { stdin: source, env: { ESLINT_USE_FLAT_CONFIG: "false" } });
 
     assert.strictEqual(result.length, 1);
     const reportedPath = toRepoPath(result[0].filePath);


### PR DESCRIPTION


## Summary

This PR adds CI coverage for the ESLint 8, 9, and 10 compatibility track, introduces docs and package smoke validation, and prepares the package for the `2.0.0-alpha.0` release.

## Changes

- Added a GitHub Actions CI workflow that runs lint and test jobs on Node 24 against ESLint 8, 9, and 10.
- Updated the CI workflow to run on all pushes and pull requests.
- Added package validation jobs for generated docs and package tarball smoke checks.
- Switched CI install and script execution to Yarn.
- Pinned both `eslint` and `@eslint/js` majors in the matrix to keep versions aligned during compatibility testing.
- Added `files` metadata in `package.json` so published package contents are explicitly scoped to `lib`, `docs`, `README.md`, and `LICENSE`.
- Added `check:docs` and `check:pack` scripts for CI validation.
- Added flat config usage docs to the README.
- Added alpha compatibility and migration notes covering Node.js, ESLint support range, config style support, and module entrypoint support.
- Bumped the package version to `2.0.0-alpha.0`.
- Updated legacy config compatibility tests to force `.eslintrc` mode explicitly for ESLint 8 and 9 by setting `ESLINT_USE_FLAT_CONFIG=false`.
- Simplified the legacy config test flag usage to consistently rely on `--no-eslintrc`.

