### PR TITLE
Add dedicated v2 migration docs and README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,6 @@ module.exports = [
   * ESLint 10: flat `eslint.config.*` only
 * Module support: CommonJS + ESM entrypoints
 
-### Migration Notes (alpha)
-
-* Prefer the flat config format for new projects.
-* Legacy `.eslintrc*` remains supported for ESLint 8/9 (ESLint 10 is flat-config-only).
-* Rule fixer hardening for alias/mixed-import edge cases is deferred to a follow-up PR.
-
 ---
 
 ## 🔍 Rule Example
@@ -138,6 +132,18 @@ const lodashEs = require('lodash-es');
 
 Importing all of lodash can significantly bloat your JS bundle.
 This plugin ensures you only import the functions you need, improving performance and clarity.
+
+---
+
+## 🔄 Migration
+
+Moving from v1 to v2?
+
+* Prefer flat config for new projects.
+* Legacy `.eslintrc*` remains available for ESLint 8/9.
+* ESLint 10 requires flat config.
+* Rule-fixer hardening for alias/mixed-import edge cases is deferred to a follow-up PR.
+* Full guide: [Migrate to v2](docs/migration/migrate-to-v2.md)
 
 ---
 

--- a/docs/migration/migrate-to-v2.md
+++ b/docs/migration/migrate-to-v2.md
@@ -1,0 +1,76 @@
+# Migrate to v2 (from v1)
+
+This guide helps you migrate from `eslint-plugin-lodash-specific-import` v1 to v2.
+
+## What changed
+
+1. Node.js minimum version is now `>=22`.
+2. ESLint support target is `^8 || ^9 || ^10`.
+3. Flat config support is now first-class.
+4. Plugin export shape is standardized to include:
+   - `meta`
+   - `rules`
+   - `configs`
+5. `lodash-specific-import/no-global` remains the rule key (no rename).
+
+## Compatibility summary
+
+1. ESLint 8/9:
+   - Legacy `.eslintrc*` is supported.
+   - Flat config is supported.
+2. ESLint 10:
+   - Use flat config only (`eslint.config.js` / `eslint.config.cjs`).
+
+## Migration checklist
+
+1. Upgrade runtime/tooling:
+   - Node.js `>=22`
+   - ESLint to 8, 9, or 10
+2. Keep the same rule key:
+   - `lodash-specific-import/no-global`
+3. Choose one config style:
+   - Legacy `.eslintrc*` for ESLint 8/9
+   - Flat config for ESLint 8/9/10 (recommended)
+
+## Config examples
+
+### Legacy config (ESLint 8/9)
+
+```json
+{
+  "extends": ["plugin:lodash-specific-import/recommended"]
+}
+```
+
+### Flat config (recommended, ESLint 8/9/10)
+
+```js
+const lodashSpecificImport = require("eslint-plugin-lodash-specific-import");
+
+module.exports = [
+  ...lodashSpecificImport.configs["flat/recommended"],
+];
+```
+
+### Manual flat config
+
+```js
+const lodashSpecificImport = require("eslint-plugin-lodash-specific-import");
+
+module.exports = [
+  {
+    plugins: {
+      "lodash-specific-import": lodashSpecificImport,
+    },
+    rules: {
+      "lodash-specific-import/no-global": "error",
+    },
+  },
+];
+```
+
+## Notes for alpha adopters
+
+1. Prefer flat config for new setups.
+2. Legacy `.eslintrc*` is kept for ESLint 8/9 only.
+3. Rule-fixer hardening for alias/mixed-import edge cases is deferred to a follow-up PR.


### PR DESCRIPTION
## Summary

This PR introduces a dedicated migration guide for upgrading from v1 to v2 and adds a new migration section in the README linking to the full documentation.

## Changes

- Added a dedicated migration guide at `docs/migration/migrate-to-v2.md`.
- Documented breaking changes including Node.js version requirements and ESLint compatibility.
- Documented plugin export structure (`meta`, `rules`, `configs`).
- Added migration checklist and configuration examples for legacy and flat ESLint configs.
- Replaced the previous inline "Migration Notes (alpha)" section in the README with a new `Migration` section.
- Linked the README migration section to the full migration guide.
