### PR TITLE
Add named ESM exports and config metadata coverage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ Object.assign(plugin.configs, {
   },
   "flat/recommended": [
     {
+      name: "lodash-specific-import/flat/recommended",
       plugins: {
         "lodash-specific-import": plugin,
       },
@@ -32,4 +33,3 @@ Object.assign(plugin.configs, {
 });
 
 module.exports = plugin;
-

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -1,3 +1,4 @@
 import plugin from "./index.js";
 
 export default plugin;
+export const { meta, rules, configs } = plugin;

--- a/tests/lib/module-exports.js
+++ b/tests/lib/module-exports.js
@@ -1,7 +1,10 @@
 const assert = require("assert");
+const { resolve } = require("path");
+const { pathToFileURL } = require("url");
 
 const cjsPlugin = require("../../lib/index.js");
-const importEsm = new Function("path", "return import(path);");
+const importEsm = (relativePath) =>
+  import(pathToFileURL(resolve(__dirname, relativePath)).href);
 
 describe("module export parity", () => {
   it("loads plugin via cjs require", () => {

--- a/tests/lib/module-exports.js
+++ b/tests/lib/module-exports.js
@@ -24,4 +24,16 @@ describe("module export parity", () => {
 
     assert.deepStrictEqual(esmKeys, cjsKeys);
   });
+
+  it("exposes named esm exports and preserves default parity", async () => {
+    const esmModule = await importEsm("../../lib/index.mjs");
+
+    assert.notStrictEqual(esmModule.meta, undefined);
+    assert.notStrictEqual(esmModule.meta, null);
+    assert.notStrictEqual(esmModule.rules, undefined);
+    assert.notStrictEqual(esmModule.rules, null);
+    assert.notStrictEqual(esmModule.configs, undefined);
+    assert.notStrictEqual(esmModule.configs, null);
+    assert.strictEqual(esmModule.default, cjsPlugin);
+  });
 });

--- a/tests/lib/plugin-shape.js
+++ b/tests/lib/plugin-shape.js
@@ -21,6 +21,10 @@ describe("plugin export shape", () => {
     });
 
     assert(Array.isArray(plugin.configs["flat/recommended"]));
+    assert.strictEqual(
+      plugin.configs["flat/recommended"][0].name,
+      "lodash-specific-import/flat/recommended"
+    );
     assert.strictEqual(plugin.configs["flat/recommended"][0].plugins["lodash-specific-import"], plugin);
     assert.deepStrictEqual(plugin.configs["flat/recommended"][0].rules, {
       "lodash-specific-import/no-global": "error",


### PR DESCRIPTION


## Summary

This PR improves the plugin’s ESM entrypoint by exposing named exports alongside the default export, and adds metadata to the flat recommended config for better config identification and tooling support.

## Changes

- Added named ESM re-exports for `meta`, `rules`, and `configs` from `lib/index.mjs`.
- Added a `name` field to the first config object in `configs["flat/recommended"]`.
- Added test coverage to verify named ESM exports are available and that the default ESM export still matches the CommonJS plugin export.
- Added test coverage to verify the `flat/recommended` config includes the expected `name` value.
- Updated the ESM dynamic import test helper to use an absolute `file://` URL instead of a relative import path.
