### PR TITLE
Align plugin entrypoint docs and raise ESLint ecmaVersion to 2022

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -6,7 +6,7 @@ module.exports = [
   {
     ignores: ["node_modules/**", "tests/fixtures/**", ".npm-cache/**"],
     languageOptions: {
-      ecmaVersion: 2020,
+      ecmaVersion: 2022,
       sourceType: "script",
       globals: {
         __dirname: "readonly",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,7 @@
+/**
+ * @fileoverview ESLint plugin entry point. Exports the plugin object
+ * with meta, rules, and configs for both legacy and flat ESLint setups.
+ */
 "use strict";
 
 const requireIndex = require("requireindex");
@@ -32,4 +36,3 @@ Object.assign(plugin.configs, {
 });
 
 module.exports = plugin;
-


### PR DESCRIPTION
 

## Summary

This PR updates the plugin entrypoint file header to better describe what the package exports and raises the flat config `ecmaVersion` from 2020 to 2022.

## Changes

- Updated the `@fileoverview` in `lib/index.js` to accurately describe the plugin entrypoint and clarify that it exports `meta`, `rules`, and `configs` for both legacy and flat ESLint setups.
- Bumped `ecmaVersion` from `2020` to `2022` in `eslint.config.cjs`.
