### PR TITLE
Add importKind RuleTester coverage for no-global rule

### DIFF
--- a/tests/lib/rules/index.js
+++ b/tests/lib/rules/index.js
@@ -1,6 +1,14 @@
 const RuleTester = require("eslint").RuleTester;
 const rule = require("../../../lib/rules/no-global");
 const eslintMajor = Number(require("eslint/package.json").version.split(".")[0]);
+let typescriptParser;
+
+try {
+  typescriptParser = require("@typescript-eslint/parser");
+} catch {
+  typescriptParser = null;
+}
+const canRunImportKindCases = Boolean(typescriptParser) && eslintMajor < 10;
 
 const ruleTester = new RuleTester(
   eslintMajor >= 9
@@ -8,10 +16,93 @@ const ruleTester = new RuleTester(
     : { parserOptions: { ecmaVersion: 2020, sourceType: "module" } }
 );
 
+const parserSpecificValidCases = canRunImportKindCases
+  ? [
+      eslintMajor >= 9
+        ? {
+            code: "import type _ from 'lodash';",
+            languageOptions: {
+              ecmaVersion: 2020,
+              sourceType: "module",
+              parser: typescriptParser,
+            },
+          }
+        : {
+            code: "import type _ from 'lodash';",
+            parser: "@typescript-eslint/parser",
+            parserOptions: {
+              ecmaVersion: 2020,
+              sourceType: "module",
+            },
+          },
+      eslintMajor >= 9
+        ? {
+            code: "import type { debounce } from 'lodash';",
+            languageOptions: {
+              ecmaVersion: 2020,
+              sourceType: "module",
+              parser: typescriptParser,
+            },
+          }
+        : {
+            code: "import type { debounce } from 'lodash';",
+            parser: "@typescript-eslint/parser",
+            parserOptions: {
+              ecmaVersion: 2020,
+              sourceType: "module",
+            },
+          },
+      eslintMajor >= 9
+        ? {
+            code: "import { type debounce } from 'lodash';",
+            languageOptions: {
+              ecmaVersion: 2020,
+              sourceType: "module",
+              parser: typescriptParser,
+            },
+          }
+        : {
+            code: "import { type debounce } from 'lodash';",
+            parser: "@typescript-eslint/parser",
+            parserOptions: {
+              ecmaVersion: 2020,
+              sourceType: "module",
+            },
+          },
+    ]
+  : [];
+
+const parserSpecificInvalidCases = canRunImportKindCases
+  ? [
+      eslintMajor >= 9
+        ? {
+            code: "import { debounce, type isEqual } from 'lodash';",
+            languageOptions: {
+              ecmaVersion: 2020,
+              sourceType: "module",
+              parser: typescriptParser,
+            },
+            errors: [{ messageId: "invalidImport" }],
+            output: "import debounce from 'lodash/debounce';",
+          }
+        : {
+            code: "import { debounce, type isEqual } from 'lodash';",
+            parser: "@typescript-eslint/parser",
+            parserOptions: {
+              ecmaVersion: 2020,
+              sourceType: "module",
+            },
+            errors: [{ messageId: "invalidImport" }],
+            output: "import debounce from 'lodash/debounce';",
+          },
+    ]
+  : [];
+
 ruleTester.run("lodash-specific-import/no-global", rule, {
   valid: [
     "import map from 'lodash/map';",
     "import map from 'lodash-es/map';",
+    ...parserSpecificValidCases,
   ],
 
   invalid: [
@@ -67,5 +158,6 @@ ruleTester.run("lodash-specific-import/no-global", rule, {
       errors: [{ messageId: "invalidImport" }],
       output: null,
     },
+    ...parserSpecificInvalidCases,
   ],
 });

--- a/tests/lib/rules/index.js
+++ b/tests/lib/rules/index.js
@@ -2,53 +2,39 @@ const RuleTester = require("eslint").RuleTester;
 const rule = require("../../../lib/rules/no-global");
 const eslintMajor = Number(require("eslint/package.json").version.split(".")[0]);
 let typescriptParser;
+let typescriptParserPath;
 
 try {
   typescriptParser = require("@typescript-eslint/parser");
+  typescriptParserPath = require.resolve("@typescript-eslint/parser");
 } catch {
   typescriptParser = null;
+  typescriptParserPath = null;
 }
 const canRunImportKindCases = Boolean(typescriptParser) && eslintMajor < 10;
 
 const ruleTester = new RuleTester(
   eslintMajor >= 9
-    ? { languageOptions: { ecmaVersion: 2020, sourceType: "module" } }
-    : { parserOptions: { ecmaVersion: 2020, sourceType: "module" } }
+    ? { languageOptions: { ecmaVersion: 2022, sourceType: "module" } }
+    : { parserOptions: { ecmaVersion: 2022, sourceType: "module" } }
 );
 
 const parserSpecificValidCases = canRunImportKindCases
   ? [
       eslintMajor >= 9
         ? {
-            code: "import type _ from 'lodash';",
-            languageOptions: {
-              ecmaVersion: 2020,
-              sourceType: "module",
-              parser: typescriptParser,
-            },
-          }
-        : {
-            code: "import type _ from 'lodash';",
-            parser: "@typescript-eslint/parser",
-            parserOptions: {
-              ecmaVersion: 2020,
-              sourceType: "module",
-            },
-          },
-      eslintMajor >= 9
-        ? {
             code: "import type { debounce } from 'lodash';",
             languageOptions: {
-              ecmaVersion: 2020,
+              ecmaVersion: 2022,
               sourceType: "module",
               parser: typescriptParser,
             },
           }
         : {
             code: "import type { debounce } from 'lodash';",
-            parser: "@typescript-eslint/parser",
+            parser: typescriptParserPath,
             parserOptions: {
-              ecmaVersion: 2020,
+              ecmaVersion: 2022,
               sourceType: "module",
             },
           },
@@ -56,16 +42,16 @@ const parserSpecificValidCases = canRunImportKindCases
         ? {
             code: "import { type debounce } from 'lodash';",
             languageOptions: {
-              ecmaVersion: 2020,
+              ecmaVersion: 2022,
               sourceType: "module",
               parser: typescriptParser,
             },
           }
         : {
             code: "import { type debounce } from 'lodash';",
-            parser: "@typescript-eslint/parser",
+            parser: typescriptParserPath,
             parserOptions: {
-              ecmaVersion: 2020,
+              ecmaVersion: 2022,
               sourceType: "module",
             },
           },
@@ -76,9 +62,30 @@ const parserSpecificInvalidCases = canRunImportKindCases
   ? [
       eslintMajor >= 9
         ? {
+            code: "import type _ from 'lodash';",
+            languageOptions: {
+              ecmaVersion: 2022,
+              sourceType: "module",
+              parser: typescriptParser,
+            },
+            errors: [{ messageId: "invalidDefaultImport" }],
+            output: null,
+          }
+        : {
+            code: "import type _ from 'lodash';",
+            parser: typescriptParserPath,
+            parserOptions: {
+              ecmaVersion: 2022,
+              sourceType: "module",
+            },
+            errors: [{ messageId: "invalidDefaultImport" }],
+            output: null,
+          },
+      eslintMajor >= 9
+        ? {
             code: "import { debounce, type isEqual } from 'lodash';",
             languageOptions: {
-              ecmaVersion: 2020,
+              ecmaVersion: 2022,
               sourceType: "module",
               parser: typescriptParser,
             },
@@ -87,9 +94,9 @@ const parserSpecificInvalidCases = canRunImportKindCases
           }
         : {
             code: "import { debounce, type isEqual } from 'lodash';",
-            parser: "@typescript-eslint/parser",
+            parser: typescriptParserPath,
             parserOptions: {
-              ecmaVersion: 2020,
+              ecmaVersion: 2022,
               sourceType: "module",
             },
             errors: [{ messageId: "invalidImport" }],


### PR DESCRIPTION


## Summary

This PR expands `no-global` rule coverage with RuleTester cases for TypeScript `importKind` syntax and updates the test setup so those cases run consistently across supported ESLint versions.

## Changes

- Added parser-aware RuleTester coverage for `import type` named imports from `lodash`.
- Added parser-aware RuleTester coverage for mixed imports such as `import { debounce, type isEqual } from 'lodash';`.
- Added an invalid test case for type-only default imports from `lodash` and asserted `invalidDefaultImport`.
- Added conditional loading for `@typescript-eslint/parser` so parser-specific cases only run when available.
- Resolved the parser path with `require.resolve("@typescript-eslint/parser")` for better cross-version RuleTester compatibility.
- Updated RuleTester base config from `ecmaVersion: 2020` to `ecmaVersion: 2022`.
- Kept importKind-specific cases gated behind `eslintMajor < 10` to avoid unsupported runs.
