### PR TITLE
Fix no-global autofix parity for aliases and mixed type/value imports

### DIFF
--- a/lib/rules/no-global.js
+++ b/lib/rules/no-global.js
@@ -17,6 +17,21 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    function getImportedName(specifier) {
+      if (!specifier.imported) {
+        return null;
+      }
+      if (specifier.imported.type === "Identifier") {
+        return specifier.imported.name;
+      }
+      if (specifier.imported.type === "Literal" && typeof specifier.imported.value === "string") {
+        return specifier.imported.value;
+      }
+      return null;
+    }
+
     return {
       ImportDeclaration(node) {
         if (node.source.value !== "lodash" && node.source.value !== "lodash-es") {
@@ -43,16 +58,38 @@ module.exports = {
         if (node.importKind && node.importKind !== "value") {
           return;
         }
-        const imports = node.specifiers
-          .filter(
-            (specifier) =>
-              specifier.type === "ImportSpecifier" &&
-              specifier.importKind !== "type"
-          )
-          .map(
-            (specifier) =>
-              `import ${specifier.imported.name} from '${node.source.value}/${specifier.imported.name}';`
-          );
+        const valueSpecifiers = node.specifiers.filter(
+          (specifier) =>
+            specifier.type === "ImportSpecifier" &&
+            specifier.importKind !== "type"
+        );
+        const typeSpecifiers = node.specifiers.filter(
+          (specifier) =>
+            specifier.type === "ImportSpecifier" &&
+            specifier.importKind === "type"
+        );
+        const imports = [];
+
+        for (const specifier of valueSpecifiers) {
+          const importedName = getImportedName(specifier);
+          const localName =
+            specifier.local && specifier.local.type === "Identifier"
+              ? specifier.local.name
+              : null;
+          if (!importedName || !localName) {
+            context.report({
+              node,
+              messageId: "invalidImport",
+            });
+            return;
+          }
+          imports.push(`import ${localName} from '${node.source.value}/${importedName}';`);
+        }
+
+        if (typeSpecifiers.length > 0) {
+          const typeSpecifierText = typeSpecifiers.map((specifier) => sourceCode.getText(specifier)).join(", ");
+          imports.push(`import { ${typeSpecifierText} } from '${node.source.value}';`);
+        }
 
         if (imports.length > 0) {
           context.report({

--- a/lib/rules/no-global.js
+++ b/lib/rules/no-global.js
@@ -91,7 +91,7 @@ module.exports = {
           imports.push(`import { ${typeSpecifierText} } from '${node.source.value}';`);
         }
 
-        if (imports.length > 0) {
+        if (valueSpecifiers.length > 0) {
           context.report({
             node,
             messageId: "invalidImport",

--- a/tests/lib/rules/index.js
+++ b/tests/lib/rules/index.js
@@ -90,7 +90,8 @@ const parserSpecificInvalidCases = canRunImportKindCases
               parser: typescriptParser,
             },
             errors: [{ messageId: "invalidImport" }],
-            output: "import debounce from 'lodash/debounce';",
+            output:
+              "import debounce from 'lodash/debounce';\nimport { type isEqual } from 'lodash';",
           }
         : {
             code: "import { debounce, type isEqual } from 'lodash';",
@@ -100,7 +101,31 @@ const parserSpecificInvalidCases = canRunImportKindCases
               sourceType: "module",
             },
             errors: [{ messageId: "invalidImport" }],
-            output: "import debounce from 'lodash/debounce';",
+            output:
+              "import debounce from 'lodash/debounce';\nimport { type isEqual } from 'lodash';",
+          },
+      eslintMajor >= 9
+        ? {
+            code: "import { debounce, type isEqual } from 'lodash-es';",
+            languageOptions: {
+              ecmaVersion: 2022,
+              sourceType: "module",
+              parser: typescriptParser,
+            },
+            errors: [{ messageId: "invalidImport" }],
+            output:
+              "import debounce from 'lodash-es/debounce';\nimport { type isEqual } from 'lodash-es';",
+          }
+        : {
+            code: "import { debounce, type isEqual } from 'lodash-es';",
+            parser: typescriptParserPath,
+            parserOptions: {
+              ecmaVersion: 2022,
+              sourceType: "module",
+            },
+            errors: [{ messageId: "invalidImport" }],
+            output:
+              "import debounce from 'lodash-es/debounce';\nimport { type isEqual } from 'lodash-es';",
           },
     ]
   : [];
@@ -117,6 +142,11 @@ ruleTester.run("lodash-specific-import/no-global", rule, {
       code: "import { map } from 'lodash';",
       errors: [{ messageId: "invalidImport" }],
       output: "import map from 'lodash/map';",
+    },
+    {
+      code: "import { map as m } from 'lodash';",
+      errors: [{ messageId: "invalidImport" }],
+      output: "import m from 'lodash/map';",
     },
     {
       code: "import {isEmpty, map} from 'lodash';",
@@ -143,6 +173,11 @@ ruleTester.run("lodash-specific-import/no-global", rule, {
       code: "import { map } from 'lodash-es';",
       errors: [{ messageId: "invalidImport" }],
       output: "import map from 'lodash-es/map';",
+    },
+    {
+      code: "import { map as m } from 'lodash-es';",
+      errors: [{ messageId: "invalidImport" }],
+      output: "import m from 'lodash-es/map';",
     },
     {
       code: "import {isEmpty, map} from 'lodash-es';",


### PR DESCRIPTION


## Summary

This PR fixes autofix behavior in the `no-global` rule so aliased lodash imports and mixed type/value imports are transformed correctly and consistently for both `lodash` and `lodash-es`.

## Changes

- Added `sourceCode` access in the rule to preserve original type import specifier text during autofix.
- Added `getImportedName` helper to safely read imported names from specifiers.
- Updated autofix logic to correctly handle aliased imports such as `import { map as m } from 'lodash';`.
- Split import specifiers into value specifiers and type specifiers before generating fixes.
- Converted value imports into per-method default imports using the local alias when present.
- Preserved type-only specifiers by re-emitting them as a grouped import from the original package.
- Added a fallback report path when imported or local names cannot be resolved safely.
- Added RuleTester coverage for aliased imports from `lodash`.
- Added RuleTester coverage for aliased imports from `lodash-es`.
- Updated mixed type/value autofix expectations for both `lodash` and `lodash-es`.
